### PR TITLE
Fix annoying error "VoodooGPIO::InterruptOccurred:Failed on attemptAction

### DIFF
--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -920,7 +920,7 @@ void VoodooGPIO::InterruptOccurred(OSObject *owner, IOInterruptEventSource *src,
     }
 }
 
-void VoodooGPIO::interruptOccurredGated() {
+IOReturn VoodooGPIO::interruptOccurredGated() {
     UInt32 inactive = 0;
     bool firstdelay = true;
     
@@ -934,4 +934,6 @@ void VoodooGPIO::interruptOccurredGated() {
     
     nInactiveCommunities = (inactive < ncommunities)? inactive : ((UInt32)ncommunities - 1);
     isInterruptBusy = false;
+    
+    return kIOReturnSuccess;
 }

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -244,7 +244,7 @@ class VoodooGPIO : public IOService {
     void intel_gpio_community_irq_handler(struct intel_community *community, bool *firstdelay);
 
     void InterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount);
-    void interruptOccurredGated();
+    IOReturn interruptOccurredGated();
 
  public:
     IOReturn getInterruptType(int pin, int *interruptType) override;


### PR DESCRIPTION
Fix error "VoodooGPIO::InterruptOccurred:Failed on attemptAction(). Error code = 4".
attemptAction takes a returned value from the called method (according to xnu sources), so interruptOccurredGated should return kIOReturnSuccess.