### PR TITLE
Fix crash when unloading

### DIFF
--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -700,8 +700,6 @@ void VoodooGPIO::stop(IOService *provider) {
     if (interruptSource) {
         interruptSource->disable();
         workLoop->removeEventSource(interruptSource);
-        // wait for pending interrupt event
-        IOSleep(500);
         OSSafeReleaseNULL(interruptSource);
     }
 

--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -700,6 +700,8 @@ void VoodooGPIO::stop(IOService *provider) {
     if (interruptSource) {
         interruptSource->disable();
         workLoop->removeEventSource(interruptSource);
+        // wait for pending interrupt event
+        IOSleep(500);
         OSSafeReleaseNULL(interruptSource);
     }
 
@@ -719,20 +721,9 @@ void VoodooGPIO::stop(IOService *provider) {
         IOSafeDeleteNULL(communities[i].pinInterruptAction, IOInterruptAction, communities[i].npins);
         IOSafeDeleteNULL(communities[i].interruptTypes, unsigned, communities[i].npins);
         IOSafeDeleteNULL(communities[i].pinInterruptRefcons, void*, communities[i].npins);
-        IOSafeDeleteNULL(communities[i].isActiveCommunity, bool, communities[i].npins);
+        IOSafeDeleteNULL(communities[i].isActiveCommunity, bool, 1);
     }
     
-    if (interruptSource) {
-        interruptSource->disable();
-        workLoop->removeEventSource(interruptSource);
-        OSSafeReleaseNULL(interruptSource);
-    }
-    
-    if (command_gate) {
-        workLoop->removeEventSource(command_gate);
-        OSSafeReleaseNULL(command_gate);
-    }
-
     OSSafeReleaseNULL(workLoop);
     
     PMstop();

--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -656,7 +656,7 @@ bool VoodooGPIO::start(IOService *provider) {
         communities[i].pinInterruptRefcons = (void **)IOMalloc(sz);
         memset(communities[i].pinInterruptRefcons, 0, sz);
         
-        communities[i].isActiveCommunity = (bool *)IOMalloc(1);;
+        communities[i].isActiveCommunity = IONew(bool, 1);
         *communities[i].isActiveCommunity = false;
     }
     nInactiveCommunities = (UInt32)ncommunities - 1;


### PR DESCRIPTION
- ~~Wait for the pending events before releasing resources.~~
- Fix the wrong size in the release of pin resources.
- Remove redundant code.

Fix crash when trying to `kextunload`, caused by the wrong size in
```cpp
IOSafeDeleteNULL(communities[i].isActiveCommunity, bool, communities[i].npins);
```
