### PR TITLE
Improve interrupt performance

### DIFF
--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -78,6 +78,9 @@ OSDefineMetaClassAndStructors(VoodooGPIO, IOService);
 #define pin_to_padno(c, p)      ((p) - (c)->pin_base)
 #define padgroup_offset(g, p)   ((p) - (g)->base)
 
+// Log only if current thread is interruptible, otherwise we will get a panic.
+#define TryLog(args...) do { if (ml_get_interrupts_enabled()) IOLog(args); } while (0)
+
 UInt32 VoodooGPIO::readl(IOVirtualAddress addr) {
     return *(const volatile UInt32 *)addr;
 }
@@ -114,7 +117,7 @@ struct intel_community *VoodooGPIO::intel_get_community(unsigned pin) {
             return community;
     }
 
-    IOLog("%s::Failed to find community for pin %u", getName(), pin);
+    TryLog("%s::Failed to find community for pin %u", getName(), pin);
     return NULL;
 }
 
@@ -125,7 +128,7 @@ struct intel_padgroup *VoodooGPIO::intel_community_get_padgroup(struct intel_com
             return padgrp;
     }
 
-    IOLog("%s::Failed to find padgroup for pin %u", getName(), pin);
+    TryLog("%s::Failed to find padgroup for pin %u", getName(), pin);
     return NULL;
 }
 
@@ -290,7 +293,7 @@ SInt32 VoodooGPIO::intel_gpio_to_pin(UInt32 offset,
         }
     }
 
-    IOLog("%s::Failed getting hardware pin for GPIO pin %u", getName(), offset);
+    TryLog("%s::Failed getting hardware pin for GPIO pin %u", getName(), offset);
     return -1;
 }
 
@@ -345,7 +348,7 @@ bool VoodooGPIO::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
      * updated by the host controller hardware.
      */
     if (intel_pad_acpi_mode(pin)) {
-        IOLog("%s:: pin %u cannot be used as IRQ\n", getName(), pin);
+        TryLog("%s:: pin %u cannot be used as IRQ\n", getName(), pin);
         return false;
     }
     

--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -732,7 +732,7 @@ void VoodooGPIO::stop(IOService *provider) {
 
     if (registered_pin_list) {
         if (registered_pin_list->getCount() > 0) {
-            IOLog("%s interrupt has not been unregistered by client", getName());
+            IOLog("%s::Interrupt has not been unregistered by client", getName());
             getProvider()->unregisterInterrupt(0);
         }
         OSSafeReleaseNULL(registered_pin_list);
@@ -899,7 +899,7 @@ IOReturn VoodooGPIO::registerInterrupt(int pin, OSObject *target, IOInterruptAct
 
     if (OSNumber* registered_pin = OSNumber::withNumber(hw_pin, 32)) {
         if (!registered_pin_list->setObject(registered_pin)) {
-            IOLog("%s unable to register pin into list", getName());
+            IOLog("%s::Unable to register pin into list", getName());
             registered_pin->release();
             return kIOReturnNoResources;
         }

--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -8,6 +8,7 @@
 
 #include "VoodooGPIO.hpp"
 
+OSDefineMetaClassAndStructors(VoodooGPIORegisteredPin, OSObject);
 OSDefineMetaClassAndStructors(VoodooGPIO, IOService);
 
 #define kIOPMPowerOff 0
@@ -605,12 +606,11 @@ bool VoodooGPIO::start(IOService *provider) {
     }
 
     interruptSource = IOInterruptEventSource::interruptEventSource(this, OSMemberFunctionCast(IOInterruptEventAction, this, &VoodooGPIO::InterruptOccurred), provider);
-    if (!interruptSource || (workLoop->addEventSource(interruptSource) != kIOReturnSuccess)) {
+    if (!interruptSource) {
         IOLog("%s::Failed to get GPIO Controller interrupt!\n", getName());
         stop(provider);
         return false;
     }
-    interruptSource->enable();
 
     IOLog("%s::VoodooGPIO Init!\n", getName());
     
@@ -675,6 +675,11 @@ bool VoodooGPIO::start(IOService *provider) {
     }
     nInactiveCommunities = (UInt32)ncommunities - 1;
     
+    registered_pin_list = OSArray::withCapacity(2);
+    if (!registered_pin_list) {
+        return false;
+    }
+
     intel_pinctrl_pm_init();
     
     isInterruptBusy = false;
@@ -734,6 +739,11 @@ void VoodooGPIO::stop(IOService *provider) {
         IOSafeDeleteNULL(communities[i].interruptTypes, unsigned, communities[i].npins);
         IOSafeDeleteNULL(communities[i].pinInterruptRefcons, void*, communities[i].npins);
         IOSafeDeleteNULL(communities[i].isActiveCommunity, bool, 1);
+    }
+
+    if (registered_pin_list) {
+        registered_pin_list->flushCollection();
+        OSSafeReleaseNULL(registered_pin_list);
     }
     
     OSSafeReleaseNULL(workLoop);
@@ -828,6 +838,38 @@ void VoodooGPIO::intel_gpio_community_irq_handler(struct intel_community *commun
     }
 }
 
+void VoodooGPIO::intel_gpio_pin_irq_handler(VoodooGPIORegisteredPin *pin) {
+    if (!pin || !pin->pending_address || !pin->enabled_address) {
+        return;
+    }
+
+    unsigned long pending, enabled;
+    pending = readl(pin->pending_address);
+    enabled = readl(pin->enabled_address);
+
+    /* Only interrupts that are enabled */
+    pending &= enabled;
+
+    if (!pending) {
+        return;
+    }
+
+    int i = pin->pin - pin->pad_pin_base;
+    if (!((pending >> i) & 0x1)) {
+        return;
+    }
+
+    OSObject *owner = pin->community->pinInterruptActionOwners[pin->pin];
+    if (owner) {
+        IOInterruptAction handler = pin->community->pinInterruptAction[pin->pin];
+        void *refcon = pin->community->pinInterruptRefcons[pin->pin];
+        handler(owner, refcon, this, pin->pin);
+    }
+
+    /* Clear interrupt status */
+    writel(static_cast<UInt32>(BIT(i)), pin->pending_address);
+}
+
 /**
  * @param pin 'Software' pin number (i.e. GpioInt)
  * @param interruptType variable to store interrupt type for specified GPIO pin.
@@ -845,7 +887,8 @@ IOReturn VoodooGPIO::getInterruptType(int pin, int *interruptType) {
  */
 IOReturn VoodooGPIO::registerInterrupt(int pin, OSObject *target, IOInterruptAction handler, void *refcon) {
     struct intel_community *community;
-    SInt32 hw_pin = intel_gpio_to_pin(pin, &community, nullptr);
+    struct intel_padgroup *padgrp;
+    SInt32 hw_pin = intel_gpio_to_pin(pin, &community, &padgrp);
     if (hw_pin < 0)
         return kIOReturnNoInterrupt;
 
@@ -855,11 +898,33 @@ IOReturn VoodooGPIO::registerInterrupt(int pin, OSObject *target, IOInterruptAct
     
     if (community->pinInterruptActionOwners[communityidx])
         return kIOReturnNoResources;
-    
-    community->pinInterruptActionOwners[communityidx] = target;
-    community->pinInterruptAction[communityidx] = handler;
-    community->pinInterruptRefcons[communityidx] = refcon;
-    *community->isActiveCommunity = true;
+
+    if (VoodooGPIORegisteredPin* registered_pin = OSTypeAlloc(VoodooGPIORegisteredPin)) {
+        registered_pin->pin = hw_pin - community->pin_base;
+        registered_pin->pad_pin_base = padgrp->base - community->pin_base;
+        registered_pin->pending_address = community->regs + GPI_IS + padgrp->reg_num * 4;
+        registered_pin->enabled_address = community->regs + community->ie_offset + padgrp->reg_num * 4;
+        registered_pin->community = community;
+        if (!registered_pin_list->setObject(registered_pin)) {
+            IOLog("%s unable to register pin into list", getName());
+            return kIOReturnNoResources;
+        }
+        registered_pin->release();
+
+        community->pinInterruptActionOwners[communityidx] = target;
+        community->pinInterruptAction[communityidx] = handler;
+        community->pinInterruptRefcons[communityidx] = refcon;
+        *community->isActiveCommunity = true;
+    } else {
+        IOLog("%s unable to allocate interrupt pin", getName());
+        return kIOReturnNoResources;
+    }
+
+    IOLog("%s::Successfully register hardware pin 0x%02X for GPIO IRQ pin 0x%02X\n", getName(), hw_pin, pin);
+
+    if (registered_pin_list->getCount() == 1) {
+        getWorkLoop()->addEventSource(interruptSource);
+    }
     return kIOReturnSuccess;
 }
 
@@ -879,6 +944,17 @@ IOReturn VoodooGPIO::unregisterInterrupt(int pin) {
     community->pinInterruptAction[communityidx] = NULL;
     community->interruptTypes[communityidx] = 0;
     community->pinInterruptRefcons[communityidx] = NULL;
+
+    for (int i = registered_pin_list->getCount() - 1; i >= 0; i--) {
+        VoodooGPIORegisteredPin* registered_pin = OSDynamicCast(VoodooGPIORegisteredPin, registered_pin_list->getObject(i));
+        if (registered_pin && registered_pin->pin == hw_pin - community->pin_base) {
+            registered_pin_list->removeObject(i);
+        }
+    }
+
+    if (registered_pin_list->getCount() == 0) {
+        getWorkLoop()->removeEventSource(interruptSource);
+    }
     return kIOReturnSuccess;
 }
 
@@ -932,14 +1008,11 @@ IOReturn VoodooGPIO::setInterruptTypeForPin(int pin, int type) {
 }
 
 void VoodooGPIO::InterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount) {
-    if (isInterruptBusy)
-        return;
-    isInterruptBusy = true;
-
-    IOReturn ret = command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &VoodooGPIO::interruptOccurredGated));
-    if (ret != kIOReturnSuccess) {
-        isInterruptBusy = false;
-        IOLog("%s:InterruptOccurred:Failed on attemptAction(). Error code = %X\n", getName(), ret);
+    for (int i = 0; i < registered_pin_list->getCount(); i++) {
+        VoodooGPIORegisteredPin* registered_pin = OSDynamicCast(VoodooGPIORegisteredPin, registered_pin_list->getObject(i));
+        if (registered_pin) {
+            intel_gpio_pin_irq_handler(registered_pin);
+        }
     }
 }
 

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -219,7 +219,6 @@ class VoodooGPIO : public IOService {
     bool controllerIsAwake;
 
     IOWorkLoop *workLoop = nullptr;
-    IOInterruptEventSource *interruptSource = nullptr;
     IOCommandGate* command_gate = nullptr;
     OSArray* registered_pin_list = nullptr;
     bool isInterruptBusy;

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -158,14 +158,6 @@ struct intel_pinctrl_context {
     struct intel_community_context *communities;
 };
 
-class VoodooGPIORegisteredPin : public OSObject {
-OSDeclareDefaultStructors(VoodooGPIORegisteredPin);
-public:
-    int hw_pin;
-    intel_padgroup *pad_group;
-    intel_community *community;
-};
-
 /* Additional features supported by the hardware */
 #define PINCTRL_FEATURE_DEBOUNCE    1
 #define PINCTRL_FEATURE_1K_PD       2
@@ -252,7 +244,7 @@ class VoodooGPIO : public IOService {
     void intel_pinctrl_resume();
 
     void intel_gpio_community_irq_handler(struct intel_community *community, bool *firstdelay);
-    void intel_gpio_pin_irq_handler(VoodooGPIORegisteredPin *pin);
+    void intel_gpio_pin_irq_handler(unsigned hw_pin);
 
     void InterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount);
     IOReturn interruptOccurredGated();

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -161,10 +161,8 @@ struct intel_pinctrl_context {
 class VoodooGPIORegisteredPin : public OSObject {
 OSDeclareDefaultStructors(VoodooGPIORegisteredPin);
 public:
-    int pin;
-    int pad_pin_base;
-    IOVirtualAddress pending_address;
-    IOVirtualAddress enabled_address;
+    int hw_pin;
+    intel_padgroup *pad_group;
     intel_community *community;
 };
 

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -158,6 +158,16 @@ struct intel_pinctrl_context {
     struct intel_community_context *communities;
 };
 
+class VoodooGPIORegisteredPin : public OSObject {
+OSDeclareDefaultStructors(VoodooGPIORegisteredPin);
+public:
+    int pin;
+    int pad_pin_base;
+    IOVirtualAddress pending_address;
+    IOVirtualAddress enabled_address;
+    intel_community *community;
+};
+
 /* Additional features supported by the hardware */
 #define PINCTRL_FEATURE_DEBOUNCE    1
 #define PINCTRL_FEATURE_1K_PD       2
@@ -211,6 +221,7 @@ class VoodooGPIO : public IOService {
     IOWorkLoop *workLoop = nullptr;
     IOInterruptEventSource *interruptSource = nullptr;
     IOCommandGate* command_gate = nullptr;
+    OSArray* registered_pin_list = nullptr;
     bool isInterruptBusy;
     UInt32 nInactiveCommunities;
 
@@ -244,6 +255,7 @@ class VoodooGPIO : public IOService {
     void intel_pinctrl_resume();
 
     void intel_gpio_community_irq_handler(struct intel_community *community, bool *firstdelay);
+    void intel_gpio_pin_irq_handler(VoodooGPIORegisteredPin *pin);
 
     void InterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount);
     IOReturn interruptOccurredGated();


### PR DESCRIPTION
- Add a list to cache info of the registered interrupt pins. Reduce the complexity of the interrupt handler.
- Passthrough direct interrupt to the IOInterruptEventSource of the client.