### PR TITLE
Fix Suspend/Resume IRQ issue

### DIFF
--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -913,6 +913,8 @@ IOReturn VoodooGPIO::unregisterInterrupt(int pin) {
     if (hw_pin < 0)
         return kIOReturnNoInterrupt;
 
+    IOLog("%s::Unregistering hardware pin 0x%02X for GPIO IRQ pin 0x%02X\n", getName(), hw_pin, pin);
+
     intel_gpio_irq_mask_unmask(hw_pin, true);
 
     unsigned communityidx = hw_pin - community->pin_base;

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -151,6 +151,7 @@ struct intel_pad_context {
 
 struct intel_community_context {
     uint32_t *intmask;
+    uint32_t *hostown;
 };
 
 struct intel_pinctrl_context {
@@ -241,6 +242,8 @@ class VoodooGPIO : public IOService {
     void intel_pinctrl_pm_release();
     void intel_pinctrl_suspend();
     void intel_gpio_irq_init();
+    UInt32 intel_gpio_is_requested(int base, unsigned int size);
+    UInt32 intel_gpio_update_pad_mode(IOVirtualAddress hostown, UInt32 mask, UInt32 value);
     void intel_pinctrl_resume();
 
     void intel_gpio_community_irq_handler(struct intel_community *community, bool *firstdelay);


### PR DESCRIPTION
Some machines will put GPIO pins back in ACPI mode after wake, making them unusable as IRQs.
This pull request ports the Linux changes making VoodooGPIO preserve host ownership status for used pins.

Partially solves VoodooI2C/VoodooI2C#388