### PR TITLE
IRQ Improvements

### DIFF
--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -978,7 +978,6 @@ IOReturn VoodooGPIOIntel::enableInterrupt(int pin) {
 
     unsigned communityidx = hw_pin - community->pin_base;
     if (community->pinInterruptActionOwners[communityidx]) {
-        intel_gpio_irq_set_type(hw_pin, community->interruptTypes[communityidx]);
         intel_gpio_irq_mask_unmask(hw_pin, false);
         return getProvider()->enableInterrupt(0);
     }
@@ -1009,6 +1008,7 @@ IOReturn VoodooGPIOIntel::setInterruptTypeForPin(int pin, int type) {
 
     unsigned communityidx = hw_pin - community->pin_base;
     community->interruptTypes[communityidx] = type;
+    intel_gpio_irq_set_type(hw_pin, type);
     return kIOReturnSuccess;
 }
 

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -320,7 +320,7 @@ bool VoodooGPIOIntel::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
 
     value = readl(reg);
 
-    value &= ~(PADCFG0_RXEVCFG_MASK | PADCFG0_RXINV);
+    value &= ~(PADCFG0_RXEVCFG_MASK | PADCFG0_RXINV | PADCFG0_PMODE_MASK);
 
     if ((type & IRQ_TYPE_EDGE_BOTH) == IRQ_TYPE_EDGE_BOTH) {
         value |= PADCFG0_RXEVCFG_EDGE_BOTH << PADCFG0_RXEVCFG_SHIFT;
@@ -336,6 +336,9 @@ bool VoodooGPIOIntel::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
         value |= PADCFG0_RXEVCFG_DISABLED << PADCFG0_RXEVCFG_SHIFT;
     }
 
+    /* Pmode of zero makes sure pin is muxed into the GPIO controller logic */
+    value &= ~PADCFG0_PMODE_MASK;
+    
     writel(value, reg);
     return true;
 }

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -876,10 +876,8 @@ void VoodooGPIOIntel::intel_gpio_pin_irq_handler(unsigned hw_pin) {
         handler(owner, refcon, this, pad_group_i + pad_group->gpio_base);
     }
 
-    if (community->interruptTypes[community_i] & IRQ_TYPE_LEVEL_MASK) {
-        /* For Level interrupts, we need to clear the interrupt status or we get too many interrupts */
-        writel(static_cast<UInt32>(BIT(pad_group_i)), pending_address);
-    }
+    /* Clear interrupt status */
+    writel(static_cast<UInt32>(BIT(pad_group_i)), pending_address);
 }
 
 /**

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -891,11 +891,19 @@ void VoodooGPIOIntel::intel_gpio_pin_irq_handler(unsigned hw_pin) {
  * @param interruptType variable to store interrupt type for specified GPIO pin.
  */
 IOReturn VoodooGPIOIntel::getInterruptType(int pin, int *interruptType) {
-    SInt32 hw_pin = intel_gpio_to_pin(pin, nullptr, nullptr);
+    struct intel_community *community;
+    SInt32 hw_pin = intel_gpio_to_pin(pin, &community, nullptr);
     if (hw_pin < 0)
         return kIOReturnNoInterrupt;
-
-    return getProvider()->getInterruptType(0, interruptType);
+    
+    unsigned communityidx = hw_pin - community->pin_base;
+    if (community->interruptTypes[communityidx] & IRQ_TYPE_LEVEL_MASK) {
+        *interruptType = kIOInterruptTypeLevel;
+    } else {
+        *interruptType = kIOInterruptTypeEdge;
+    }
+    
+    return kIOReturnSuccess;
 }
 
 /**

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -696,13 +696,6 @@ bool VoodooGPIOIntel::start(IOService *provider) {
             continue;
         }
         memset(communities[i].pinInterruptRefcons, 0, sizeof(void *) * communities[i].npins);
-
-        communities[i].isActiveCommunity = IONew(bool, 1);
-        if (!communities[i].isActiveCommunity) {
-            IOLog("%s::Error allocating isActiveCommunity for community %d\n", getName(), i);
-            continue;
-        }
-        *communities[i].isActiveCommunity = false;
     }
     nInactiveCommunities = (UInt32)ncommunities - 1;
 
@@ -766,7 +759,6 @@ void VoodooGPIOIntel::stop(IOService *provider) {
         IOSafeDeleteNULL(communities[i].pinInterruptAction, IOInterruptAction, communities[i].npins);
         IOSafeDeleteNULL(communities[i].interruptTypes, unsigned, communities[i].npins);
         IOSafeDeleteNULL(communities[i].pinInterruptRefcons, void*, communities[i].npins);
-        IOSafeDeleteNULL(communities[i].isActiveCommunity, bool, 1);
         OSSafeReleaseNULL(communities[i].mmap);
     }
 
@@ -930,7 +922,6 @@ IOReturn VoodooGPIOIntel::registerInterrupt(int pin, OSObject *target, IOInterru
         community->pinInterruptActionOwners[communityidx] = target;
         community->pinInterruptAction[communityidx] = handler;
         community->pinInterruptRefcons[communityidx] = refcon;
-        *community->isActiveCommunity = true;
     } else {
         IOLog("%s::Unable to allocate interrupt pin", getName());
         return kIOReturnNoResources;
@@ -1018,8 +1009,6 @@ IOReturn VoodooGPIOIntel::setInterruptTypeForPin(int pin, int type) {
 
     unsigned communityidx = hw_pin - community->pin_base;
     community->interruptTypes[communityidx] = type;
-    if (type & IRQ_TYPE_LEVEL_MASK)
-        *community->isActiveCommunity = true;
     return kIOReturnSuccess;
 }
 

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -320,7 +320,7 @@ bool VoodooGPIOIntel::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
 
     value = readl(reg);
 
-    value &= ~(PADCFG0_RXEVCFG_MASK | PADCFG0_RXINV);
+    value &= ~(PADCFG0_RXEVCFG_MASK | PADCFG0_RXINV | PADCFG0_PMODE_MASK);
 
     if ((type & IRQ_TYPE_EDGE_BOTH) == IRQ_TYPE_EDGE_BOTH) {
         value |= PADCFG0_RXEVCFG_EDGE_BOTH << PADCFG0_RXEVCFG_SHIFT;
@@ -712,15 +712,7 @@ bool VoodooGPIOIntel::start(IOService *provider) {
 
     isInterruptBusy = false;
     controllerIsAwake = true;
-    
-    IOReturn success = provider->registerInterrupt(0, this, OSMemberFunctionCast(IOInterruptAction, this, &VoodooGPIOIntel::InterruptOccurred));
-    if (success != kIOReturnSuccess) {
-        IOLog("%s::Error registering interrupt", getName());
-        stop(provider);
-        return false;
-    }
-    
-    provider->enableInterrupt(0);
+
     registerService();
 
     // Declare an array of two IOPMPowerState structures (kMyNumberOfStates = 2).
@@ -772,10 +764,15 @@ void VoodooGPIOIntel::stop(IOService *provider) {
         IOSafeDeleteNULL(communities[i].pinInterruptRefcons, void*, communities[i].npins);
         OSSafeReleaseNULL(communities[i].mmap);
     }
-    
-    getProvider()->unregisterInterrupt(0);
-    
-    OSSafeReleaseNULL(this->registered_pin_list);
+
+    if (registered_pin_list) {
+        if (registered_pin_list->getCount() > 0) {
+            IOLog("%s::Interrupt has not been unregistered by client\n", getName());
+            getProvider()->unregisterInterrupt(0);
+        }
+        OSSafeReleaseNULL(this->registered_pin_list);
+    }
+
     OSSafeReleaseNULL(workLoop);
 
     PMstop();
@@ -941,6 +938,9 @@ IOReturn VoodooGPIOIntel::registerInterrupt(int pin, OSObject *target, IOInterru
 
     IOLog("%s::Successfully registered hardware pin 0x%02X for GPIO IRQ pin 0x%02X\n", getName(), hw_pin, pin);
 
+    if (registered_pin_list->getCount() == 1) {
+        return getProvider()->registerInterrupt(0, this, OSMemberFunctionCast(IOInterruptAction, this, &VoodooGPIOIntel::InterruptOccurred));
+    }
     return kIOReturnSuccess;
 }
 
@@ -988,7 +988,7 @@ IOReturn VoodooGPIOIntel::enableInterrupt(int pin) {
     unsigned communityidx = hw_pin - community->pin_base;
     if (community->pinInterruptActionOwners[communityidx]) {
         intel_gpio_irq_mask_unmask(hw_pin, false);
-        return kIOReturnSuccess;
+        return getProvider()->enableInterrupt(0);
     }
     return kIOReturnNoInterrupt;
 }
@@ -1002,7 +1002,7 @@ IOReturn VoodooGPIOIntel::disableInterrupt(int pin) {
         return kIOReturnNoInterrupt;
 
     intel_gpio_irq_mask_unmask(hw_pin, true);
-    return kIOReturnSuccess;
+    return getProvider()->disableInterrupt(0);
 }
 
 /**

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -336,7 +336,7 @@ bool VoodooGPIOIntel::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
     } else {
         value |= PADCFG0_RXEVCFG_DISABLED << PADCFG0_RXEVCFG_SHIFT;
     }
-    
+
     writel(value, reg);
     return true;
 }

--- a/VoodooGPIO/VoodooGPIOIntel.cpp
+++ b/VoodooGPIO/VoodooGPIOIntel.cpp
@@ -320,6 +320,7 @@ bool VoodooGPIOIntel::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
 
     value = readl(reg);
 
+    /* Pmode of zero makes sure pin is muxed into the GPIO controller logic */
     value &= ~(PADCFG0_RXEVCFG_MASK | PADCFG0_RXINV | PADCFG0_PMODE_MASK);
 
     if ((type & IRQ_TYPE_EDGE_BOTH) == IRQ_TYPE_EDGE_BOTH) {
@@ -335,9 +336,6 @@ bool VoodooGPIOIntel::intel_gpio_irq_set_type(unsigned pin, unsigned type) {
     } else {
         value |= PADCFG0_RXEVCFG_DISABLED << PADCFG0_RXEVCFG_SHIFT;
     }
-
-    /* Pmode of zero makes sure pin is muxed into the GPIO controller logic */
-    value &= ~PADCFG0_PMODE_MASK;
     
     writel(value, reg);
     return true;

--- a/VoodooGPIO/VoodooGPIOIntel.hpp
+++ b/VoodooGPIO/VoodooGPIOIntel.hpp
@@ -104,7 +104,6 @@ struct intel_community {
     struct intel_padgroup *gpps;
     size_t ngpps;
     bool gpps_alloc;
-    bool *isActiveCommunity;
     /* Reserved for the core driver */
     IOMemoryMap *mmap;
     IOVirtualAddress regs;


### PR DESCRIPTION
I'm not entirely sure what to name this PR honestly, since it's all a bunch of small changes. I was helping out @theroadw with a touchpad that keeps the IRQ line asserted and wrote these changes in an attempt to figure help troubleshoot it.

Notes on each of the commits:
- Remove unused isCommunityActive
- Only set IRQ type on resume/register
  - IOInterruptEventSource calls disableInterrupt/enableInterrupt automatically on a level interrupt, so setting the pin type was being called every time a touchpad received an interrupt.
  - VoodooGPIO should save off all the pad configuration registers on sleep so I don't believe this needs to be called on wakeup.
- Always clear interrupt status on IRQ
  - I think 99% of I2C devices uses level interrupts so this was never an issue, but the linux driver does always clear this bit. Datasheets also suggest that this isn't specific to level interrupts.
- Mux pin into GPIO controller logic
  - Copied from the linux implementation, makes sure that the pin wasn't routed to another block of hardware.
- Fix pmode being removed twice from pad config
  - I meant to split this into two commits, as it hides a pretty big change to how interrupts are handled.
  - This leaves interrupts always enabled so that the IOInterruptEventSource disabling an interrupt temporarily doesn't prevent other devices from receiving IRQs. Disabling still masks the interrupt so I think this should be fine.
- Return interrupt type for GPIO pin rather than overall GPIO controller
  - IOInterruptEventSource does test the interrupt type to check if it should be disabling/enabling interrupts. Was a pretty quick thing to add but since everything uses level interrupts, the behavior doesn't really change in the end.